### PR TITLE
Add advanced warn and punishment system

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -24,15 +24,15 @@ const commands = [
                 .setRequired(false)),
     
     new SlashCommandBuilder()
-        .setName('unmute')
-        .setDescription('Manually unmutes a user using their punishment ID.')
+        .setName('remove-punishment')
+        .setDescription('Removes a mute or ban by its ID.')
         .addStringOption(option =>
-            option.setName('mute_id')
+            option.setName('id')
                 .setDescription('The ID of the punishment to remove.')
                 .setRequired(true))
         .addStringOption(option =>
             option.setName('reason')
-                .setDescription('The reason for the unmute.')
+                .setDescription('Reason for removal.')
                 .setRequired(false)),
 
     new SlashCommandBuilder()


### PR DESCRIPTION
## Summary
- redesign moderation alert to include warn count and punishment info
- track warnings and punishments in JSON files
- escalate punishments automatically and implement ban role
- add `/remove-punishment` command and update deploy script

## Testing
- `node -v`
- `node --check index.js`


------
https://chatgpt.com/codex/tasks/task_e_68484114e708832c973601ad16961fd8