### PR TITLE
Add staff bypass checks

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -10,7 +10,7 @@ const commands = [
     new SlashCommandBuilder()
         .setName('mute')
         .setDescription('Mutes a user for a specified duration.')
-        .addUserOption(option => 
+        .addUserOption(option =>
             option.setName('user')
                 .setDescription('The user to mute.')
                 .setRequired(true))
@@ -21,6 +21,18 @@ const commands = [
         .addStringOption(option =>
             option.setName('reason')
                 .setDescription('The reason for the mute.')
+                .setRequired(false)),
+
+    new SlashCommandBuilder()
+        .setName('warn')
+        .setDescription('Warns a user and applies an automatic punishment.')
+        .addUserOption(option =>
+            option.setName('user')
+                .setDescription('The user to warn.')
+                .setRequired(true))
+        .addStringOption(option =>
+            option.setName('reason')
+                .setDescription('The reason for the warning.')
                 .setRequired(false)),
     
     new SlashCommandBuilder()


### PR DESCRIPTION
## Summary
- define a helper to identify server owner or staff members
- prevent `/mute` and `/warn` from targeting staff or the owner
- skip auto-moderation for staff

## Testing
- `node -c index.js`
- `node -c deploy-commands.js`


------
https://chatgpt.com/codex/tasks/task_e_68484ce97508832ca6be3e07347dbe27