### PR TITLE
Implement /clear-message command

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -54,6 +54,18 @@ const commands = [
             option.setName('user')
                 .setDescription('The user to check.')
                 .setRequired(true)),
+
+    new SlashCommandBuilder()
+        .setName('clear-message')
+        .setDescription('Bulk deletes a number of recent messages.')
+        .addIntegerOption(option =>
+            option.setName('count')
+                .setDescription('Number of messages to delete (max 100).')
+                .setRequired(true))
+        .addUserOption(option =>
+            option.setName('user')
+                .setDescription('Only delete messages from this user.')
+                .setRequired(false)),
 ]
 .map(command => command.toJSON());
 


### PR DESCRIPTION
## Summary
- add new `/clear-message` command for moderators to bulk delete messages
- include `clear-message` in command registration and permissions check
- support filtering by user and message count

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684da0d6b5bc832caafccf3631e33703